### PR TITLE
Add Swift Package Manager integration (Phase 1.1)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftSGP4",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+        .macCatalyst(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "SwiftSGP4",
+            targets: ["SwiftSGP4"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // No external dependencies - pure Swift implementation
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "SwiftSGP4",
+            path: "SwiftSGP4"),
+        .testTarget(
+            name: "SwiftSGP4Tests",
+            dependencies: ["SwiftSGP4"],
+            path: "SwiftSGP4Tests"),
+    ]
+)


### PR DESCRIPTION
- Created Package.swift manifest with Swift tools version 5.9
- Defined SwiftSGP4 library target
- Defined SwiftSGP4Tests test target with proper dependencies
- Set platform requirements (macOS 10.15+, iOS 13+, etc.)
- Configured as pure Swift implementation (no external dependencies)

This completes Phase 1.1 of the implementation plan, enabling the project to be built and distributed via Swift Package Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)