### PR TITLE
Update misleading error message for deep-space propagation

### DIFF
--- a/SwiftSGP4/SGP4Propagator.swift
+++ b/SwiftSGP4/SGP4Propagator.swift
@@ -403,7 +403,8 @@ public enum PropagationError: Error {
     case .orbitDecayed:
       return "Satellite orbit has decayed"
     case .deepSpaceNotImplemented:
-      return "Deep space (SDP4) propagation not yet implemented"
+      return
+        "This satellite requires deep-space propagation (SDP4). Use PropagatorFactory.create() to automatically select the appropriate propagator."
     case .invalidEccentricity:
       return "Eccentricity out of valid range (0 <= e < 1)"
     case .keplerConvergenceFailed:


### PR DESCRIPTION
Changed error message from "Deep space (SDP4) propagation not yet implemented" to a more accurate message that guides users to use PropagatorFactory.create().

SDP4 is fully implemented in the codebase - this error is thrown when someone tries to use SGP4Propagator directly for a deep-space orbit, when they should use the factory for automatic propagator selection.