### PR TITLE
Add weekly schedule to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [ main, master ]
   schedule:
-    - cron: '0 0 * * 0'  # Runs every Sunday at midnight UTC
+    - cron: '0 9 * * 1'  # Runs every Monday at 9:00 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ '*' ]
   push:
     branches: [ main, master ]
+  schedule:
+    - cron: '0 0 * * 0'  # Runs every Sunday at midnight UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- CI now runs automatically every Sunday at midnight UTC
- Helps catch issues early with regular automated testing